### PR TITLE
Added verbiage to add action re encryption

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/AddSettingAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/AddSettingAction.cs
@@ -9,7 +9,7 @@ using Azure.Functions.Cli.Common;
 
 namespace Azure.Functions.Cli.Actions.LocalActions
 {
-    [Action(Name = "add", Context = Context.Settings, HelpText = "Add new local app setting to appsettings.json")]
+    [Action(Name = "add", Context = Context.Settings, HelpText = "Add new local app setting to appsettings.json.\n\t Settings are encrypted by default. If encrypted, they can only be decrypted on the current machine.")]
     class AddSettingAction : BaseAction
     {
         private readonly ISecretsManager _secretsManager;


### PR DESCRIPTION
added in verbiage to the add settings action letting the user know that the setting will be encrypted and the file will not be portable.