### PR TITLE
disable auto generation of binding redirects

### DIFF
--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>func</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>


### PR DESCRIPTION
After adding the Azure Search .NET SDK to an existing function, I received the 'Inheritance security rules violated by type' error documented in issue [#11100](https://github.com/dotnet/corefx/issues/11100) in the corefx repo. Our project was using neither .NET 4.6.1 nor System.Net.Http 4.1.1, but I discovered the functions tooling shipped with and was loading version 4.1.1.0 of System.Net.Http. I checked the distributed func.exe.config and saw a binding redirect to 4.1.1.0, but saw a binding redirect to 4.0.0.0 in the app.config from the source. I built the project with detailed logging and saw the following in the logs:

```
There was a conflict between "System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
"System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not.

C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Microsoft.Common.CurrentVersion.targets(2042,5): warning MSB3836: The explicit binding redirect on "System.Net.Http, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" xmlns="urn:schemas-microsoft-com:asm.v1" />".
```

I'm not sure if disabling AutoGenerateBindingRedirects is the best fix, but it did produce the correct func.exe.config, and let me use the Azure Search SDK in my function.