### PR TITLE
Enable worker targets on osx/linux

### DIFF
--- a/src/Azure.Functions.Cli/npm/package-lock.json
+++ b/src/Azure.Functions.Cli/npm/package-lock.json
@@ -1,16 +1,12 @@
 {
   "name": "azure-functions-core-tools",
-  "version": "2.0.1-beta.4",
+  "version": "2.0.1-beta.12",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "requires": {
-        "color-convert": "1.9.0"
-      }
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -25,11 +21,7 @@
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
-      }
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk="
     },
     "bluebird": {
       "version": "3.4.7",
@@ -39,11 +31,7 @@
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.1",
@@ -63,28 +51,17 @@
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": "0.3.9"
-      }
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg="
     },
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.2.1"
-      }
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ=="
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o="
     },
     "color-name": {
       "version": "1.1.3",
@@ -109,10 +86,7 @@
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "requires": {
-        "readable-stream": "2.1.5"
-      }
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -127,26 +101,12 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -161,11 +121,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -185,10 +141,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "0.0.8",
@@ -198,18 +151,12 @@
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -229,24 +176,12 @@
     "readable-stream": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-      "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "0.10.31",
-        "util-deprecate": "1.0.2"
-      }
+      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA="
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -261,18 +196,12 @@
     "supports-color": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-      "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-      "requires": {
-        "has-flag": "2.0.0"
-      }
+      "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA=="
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="
     },
     "traverse": {
       "version": "0.3.9",
@@ -282,18 +211,7 @@
     "unzipper": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.9.tgz",
-      "integrity": "sha512-IgZkypBqL5dTjxTc00n2PxMVtdWBDvozkf94h3nibrHPV28nDhmJmF80GLbPXjFCvuYV8sr72dJjXsmXR5Qjfw==",
-      "requires": {
-        "big-integer": "1.6.24",
-        "binary": "0.3.0",
-        "bluebird": "3.4.7",
-        "buffer-indexof-polyfill": "1.0.1",
-        "duplexer2": "0.1.4",
-        "fstream": "1.0.11",
-        "listenercount": "1.0.1",
-        "readable-stream": "2.1.5",
-        "setimmediate": "1.0.5"
-      }
+      "integrity": "sha512-IgZkypBqL5dTjxTc00n2PxMVtdWBDvozkf94h3nibrHPV28nDhmJmF80GLbPXjFCvuYV8sr72dJjXsmXR5Qjfw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/src/Azure.Functions.Cli/npm/package.json
+++ b/src/Azure.Functions.Cli/npm/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "command-exists": "^1.2.2",
+    "glob": "^7.1.2",
     "rimraf": "^2.6.1",
     "tmp": "^0.0.33",
     "unzipper": "^0.8.9"


### PR DESCRIPTION
If a .targets file is in the worker directory, we'll execute the logic on install.

This enables consistent install logic between VS project & cli.

Example worker target which installs the correct grpc native module for platform: https://github.com/Azure/azure-functions-nodejs-worker/blob/dev/Microsoft.Azure.Functions.NodeJsWorker.targets