### PR TITLE
Remove node engine restriction

### DIFF
--- a/src/Azure.Functions.Cli/npm/package.json
+++ b/src/Azure.Functions.Cli/npm/package.json
@@ -24,9 +24,6 @@
     "darwin",
     "linux"
   ],
-  "engines": {
-    "node": ">=8.4.0"
-  },
   "dependencies": {
     "chalk": "^2.1.0",
     "command-exists": "^1.2.2",


### PR DESCRIPTION
Causes issues when installing `@core` if the restriction is not met - instead of seeing an error, one of the 1.0.0 versions is installed.