### PR TITLE
Add --script-root option to host start

### DIFF
--- a/src/Azure.Functions.Cli/Actions/AzureActions/AddStorageAccountSettingAction.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/AddStorageAccountSettingAction.cs
@@ -57,7 +57,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 var name = $"{storageAccount.StorageAccountName}_STORAGE";
                 _secretsManager.SetSecret(name, storageAccount.GetConnectionString());
                 ColoredConsole
-                    .WriteLine($"Secret saved locally in {SecretsManager.AppSettingsFileName} under name {ExampleColor(name)}.")
+                    .WriteLine($"Secret saved locally in {_secretsManager.AppSettingsFileName} under name {ExampleColor(name)}.")
                     .WriteLine();
             }
         }

--- a/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionApp.cs
+++ b/src/Azure.Functions.Cli/Actions/AzureActions/PublishFunctionApp.cs
@@ -138,7 +138,7 @@ namespace Azure.Functions.Cli.Actions.AzureActions
                 if (result.ContainsKeyCaseInsensitive(pair.Key) &&
                     !result.GetValueCaseInsensitive(pair.Key).Equals(pair.Value, StringComparison.OrdinalIgnoreCase))
                 {
-                    ColoredConsole.WriteLine($"App setting {pair.Key} is different between azure and {SecretsManager.AppSettingsFileName}");
+                    ColoredConsole.WriteLine($"App setting {pair.Key} is different between azure and {_secretsManager.AppSettingsFileName}");
                     if (OverwriteSettings)
                     {
                         ColoredConsole.WriteLine("Overwriting setting in azure with local value because '--overwrite-settings [-y]' was specified.");

--- a/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/InitAction.cs
@@ -49,7 +49,7 @@ appsettings.json
 local.settings.json
 "},
             { new Lazy<string>(() => ScriptConstants.HostMetadataFileName), "{ }" },
-            { new Lazy<string>(() => SecretsManager.AppSettingsFileName), @"{
+            { new Lazy<string>(() => new SecretsManager().AppSettingsFileName), @"{
   ""IsEncrypted"": false,
   ""Values"": {
     ""AzureWebJobsStorage"": """"

--- a/src/Azure.Functions.Cli/Common/SecretsManager.cs
+++ b/src/Azure.Functions.Cli/Common/SecretsManager.cs
@@ -17,12 +17,23 @@ namespace Azure.Functions.Cli.Common
     {
         private static bool warningPrinted = false;
         private const string reason = "secrets.manager.1";
+        private readonly string _scriptRoot;
 
-        public static string AppSettingsFilePath
+        internal SecretsManager(string scriptRoot)
+        {
+            _scriptRoot = scriptRoot;
+        }
+
+        internal SecretsManager()
+            : this(Environment.CurrentDirectory)
+        {
+        }
+
+        public string AppSettingsFilePath
         {
             get
             {
-                var rootPath = ScriptHostHelpers.GetFunctionAppRootDirectory(Environment.CurrentDirectory);
+                var rootPath = ScriptHostHelpers.GetFunctionAppRootDirectory(_scriptRoot);
                 var newFilePath = Path.Combine(rootPath, "local.settings.json");
                 var oldFilePath = Path.Combine(rootPath, "appsettings.json");
                 if (!FileSystemHelpers.FileExists(oldFilePath))
@@ -54,7 +65,7 @@ namespace Azure.Functions.Cli.Common
             }
         }
 
-        public static string AppSettingsFileName
+        public string AppSettingsFileName
         {
             get
             {

--- a/src/Azure.Functions.Cli/Interfaces/ISecretsManager.cs
+++ b/src/Azure.Functions.Cli/Interfaces/ISecretsManager.cs
@@ -5,6 +5,7 @@ namespace Azure.Functions.Cli.Interfaces
 {
     internal interface ISecretsManager
     {
+        string AppSettingsFileName { get; }
         IDictionary<string, string> GetSecrets();
         IEnumerable<ConnectionString> GetConnectionStrings();
         void SetSecret(string name, string value);


### PR DESCRIPTION
resolves #264

@ahmelsayed unfortunately this is more hacky than I want it to be.

The main issue is that ISecretsManager is created via the Autofac container registry, but I need to configure it with the proper script root path to search for AppSettingsFilePath.

With the way the actions are set up, I don't know that there's a good way to use autofac's lambdas or provider patterns in order to supply the scriptRoot argument to the secrets manager - I'd love any input you have on that.

One possibility is that we could ignore ISecretsManager altogether and use local.settings.json that exists on the cwd, not the ScriptRoot. This might be more reasonable, will revisit tomorrow.

TODO: reapply defaults from hostSettings