### PR TITLE
Add extensions command

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/AddExtensionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/AddExtensionAction.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Functions.Cli.Interfaces;
+using Colors.Net;
+using Fclp;
+using System.Runtime.InteropServices;
+using static Azure.Functions.Cli.Common.OutputTheme;
+using Azure.Functions.Cli.Common;
+using System.IO;
+
+namespace Azure.Functions.Cli.Actions.LocalActions
+{
+    [Action(Name = "add", Context = Context.Extensions, HelpText = "Create a new function from a template.")]
+    internal class AddExtensionAction : BaseAction
+    {
+        public string Package { get; set; }
+        public string Version { get; set; }
+
+        public string OutputPath { get; set; }
+
+        public AddExtensionAction()
+        {
+        }
+
+        public override ICommandLineParserResult ParseArgs(string[] args)
+        {
+            Parser
+                .Setup<string>('p', "package")
+                .WithDescription("Extension package")
+                .Callback(p => Package = p)
+                .Required();
+
+            Parser
+                .Setup<string>('v', "version")
+                .WithDescription("Extension version")
+                .Callback(v => Version = v)
+                .Required();
+
+            Parser
+                .Setup<string>('o', "output")
+                .WithDescription("Output path")
+                .SetDefault(Path.Combine(".", "bin"))
+                .Callback(o => OutputPath = Path.GetFullPath(o));
+
+            return Parser.Parse(args);
+        }
+
+        public async override Task RunAsync()
+        {
+            var extensionsDir = Path.Combine(Environment.CurrentDirectory, "functions-extensions");
+            var extensionsProj = Path.Combine(extensionsDir, "extensions.csproj");
+            if (!FileSystemHelpers.FileExists(extensionsProj))
+            {
+                FileSystemHelpers.EnsureDirectory(extensionsDir);
+                var assembly = typeof(AddExtensionAction).Assembly;
+                var extensionsProjText = string.Empty;
+                using (Stream resource = assembly.GetManifestResourceStream(assembly.GetName().Name + ".ExtensionsProj.txt"))
+                using (var reader = new StreamReader(resource))
+                {
+                    while (!reader.EndOfStream)
+                    {
+                        var line = await reader.ReadLineAsync();
+                        extensionsProjText += $"{line}{Environment.NewLine}";
+                    }
+                }
+                await FileSystemHelpers.WriteAllTextToFileAsync(extensionsProj, extensionsProjText);
+            }
+
+            var addPackage = new Executable("dotnet", $"add {extensionsProj} package {Package} --version {Version}");
+            await addPackage.RunAsync(
+                (output) => ColoredConsole.WriteLine(Path.GetDirectoryName(output)),
+                (error) => ColoredConsole.WriteLine(ErrorColor(error))
+            );
+
+            var installExtensions = new Executable("dotnet", $"build {extensionsProj} -o {OutputPath}");
+            await installExtensions.RunAsync(
+                (output) => ColoredConsole.WriteLine(output),
+                (error) => ColoredConsole.WriteLine(ErrorColor(error))
+            );
+        }
+    }
+}

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -14,6 +14,12 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Properties\ExtensionsProj.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ExtensionsProj.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.1" />
     <PackageReference Include="Colors.Net" Version="1.1.0" />
     <PackageReference Include="AccentedCommandLineParser" Version="1.0.0" />

--- a/src/Azure.Functions.Cli/ConsoleApp.cs
+++ b/src/Azure.Functions.Cli/ConsoleApp.cs
@@ -23,7 +23,7 @@ namespace Azure.Functions.Cli
         private readonly IContainer _container;
         private readonly string[] _args;
         private readonly IEnumerable<TypeAttributePair> _actionAttributes;
-        private readonly string[] _helpArgs = new[] { "help", "h", "?", "version", "v" };
+        private readonly string[] _helpArgs = new[] { "help", "h", "?" };
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         public static void Run<T>(string[] args, IContainer container)

--- a/src/Azure.Functions.Cli/Context.cs
+++ b/src/Azure.Functions.Cli/Context.cs
@@ -31,7 +31,10 @@ namespace Azure.Functions.Cli
         Settings,
 
         [Description("Commands for listing available function templates")]
-        Templates
+        Templates,
+
+        [Description("Commands for installing extensions")]
+        Extensions
     }
 
     internal static class ContextEnumExtensions

--- a/src/Azure.Functions.Cli/ExtensionsProj.txt
+++ b/src/Azure.Functions.Cli/ExtensionsProj.txt
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.0-beta2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
resolves #265 

@fabiocav @ahmelsayed 

`func extensions add --package Microsoft.Azure.WebJobs.Extensions.EventHubs --version 3.0.0-beta3 --output ./bin`

creates `functions-extensions/extensions.csproj` with metadata generator included, adds event hubs nuget, runs a build on `extensions.csproj` to `--output` dir