### PR TITLE
Update to latest runtime version of WebJobs.Script

### DIFF
--- a/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
+++ b/src/Azure.Functions.Cli/Actions/HostActions/StartHostAction.cs
@@ -169,7 +169,7 @@ namespace Azure.Functions.Cli.Actions.HostActions
 
                 foreach (var function in httpFunctions)
                 {
-                    var httpRoute = function.Metadata.Bindings.FirstOrDefault(b => b.Type == "httpTrigger").Raw["route"]?.ToString();
+                    var httpRoute = function.Metadata.Bindings.FirstOrDefault(b => b.Type == "httpTrigger")?.Raw["route"]?.ToString();
                     httpRoute = httpRoute ?? function.Name;
                     var extensions = hostManager.Instance.ScriptConfig.HostConfig.GetService<IExtensionRegistry>();
                     var httpConfig = extensions.GetExtensions<IExtensionConfigProvider>().OfType<HttpExtensionConfiguration>().Single();

--- a/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
+++ b/src/Azure.Functions.Cli/Azure.Functions.Cli.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -107,6 +107,9 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNet.Razor, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.AspNet.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNet.WebHooks.Common, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebHooks.Common.1.2.0\lib\net45\Microsoft.AspNet.WebHooks.Common.dll</HintPath>
       <Private>True</Private>
@@ -199,8 +202,17 @@
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Client, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Client.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.AppService.Proxy.Client.Contract, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.Client.Contract.0.3.2.5\lib\net461\Microsoft.Azure.AppService.Proxy.Client.Contract.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Common, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Runtime, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
@@ -259,13 +271,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11351\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11375\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.WebHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11351\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11375\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
@@ -339,6 +351,9 @@
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.1.3\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.3\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
       <Private>True</Private>
@@ -381,6 +396,9 @@
     </Reference>
     <Reference Include="NuGet.Versioning, Version=3.4.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.3.4.3\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>

--- a/src/Azure.Functions.Cli/packages.config
+++ b/src/Azure.Functions.Cli/packages.config
@@ -6,6 +6,7 @@
   <package id="Autofac.WebApi2" version="4.0.1" targetFramework="net461" />
   <package id="Colors.Net" version="1.0.7" targetFramework="net461" />
   <package id="Edge.js" version="6.11.3" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="FluentCommandLineParser" version="1.4.3" targetFramework="net461" />
   <package id="FSharp.Compiler.Service" version="9.0.1" targetFramework="net461" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net461" />
@@ -48,6 +49,7 @@
   <package id="Microsoft.AspNetCore.Http.Features" version="1.0.2" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.WebUtilities" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net461" />
+  <package id="Microsoft.Azure.AppService.Proxy" version="0.3.2.14" targetFramework="net461" />
   <package id="Microsoft.Azure.AppService.Proxy.Client.Contract" version="0.3.2.5" targetFramework="net461" />
   <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net461" />
   <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net461" />
@@ -69,9 +71,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Logging" version="2.1.0-beta4-11064" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11351" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11375" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11351" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11375" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
@@ -108,6 +110,7 @@
   <package id="NuGet.Frameworks" version="3.4.3" targetFramework="net461" />
   <package id="NuGet.LibraryModel" version="3.4.3" targetFramework="net461" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net461" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net461" />
   <package id="RestSharp" version="105.2.3" targetFramework="net461" />
   <package id="Sendgrid" version="8.0.5" targetFramework="net461" />
   <package id="SendGrid.CSharp.HTTP.Client" version="3.0.0" targetFramework="net461" />

--- a/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
+++ b/test/Azure.Functions.Cli.Tests/Azure.Functions.Cli.Tests.csproj
@@ -97,8 +97,20 @@
     <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNet.Razor, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.AspNet.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Client, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Common, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.AppService.Proxy.Runtime, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.AppService.Proxy.0.3.2.14\lib\net461\Microsoft.Azure.AppService.Proxy.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
@@ -154,13 +166,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11351\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.1.0.0-beta3-11375\lib\net451\Microsoft.Azure.WebJobs.Script.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-beta3-10955\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Script.WebHost, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11351\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.WebHost.1.0.0-beta3-11375\lib\net451\Microsoft.Azure.WebJobs.Script.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.1.0-beta4-11064\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
@@ -216,6 +228,9 @@
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.3\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
@@ -262,6 +277,9 @@
     </Reference>
     <Reference Include="NuGet.Versioning, Version=3.4.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.3.4.3\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>

--- a/test/Azure.Functions.Cli.Tests/packages.config
+++ b/test/Azure.Functions.Cli.Tests/packages.config
@@ -6,6 +6,7 @@
   <package id="Castle.Core" version="4.1.0" targetFramework="net461" />
   <package id="Colors.Net" version="1.0.7" targetFramework="net461" />
   <package id="Edge.js" version="6.11.3" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="FluentAssertions" version="4.18.0" targetFramework="net461" />
   <package id="FluentCommandLineParser" version="1.4.3" targetFramework="net461" />
   <package id="FSharp.Compiler.Service" version="9.0.1" targetFramework="net461" />
@@ -19,6 +20,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net461" />
+  <package id="Microsoft.Azure.AppService.Proxy" version="0.3.2.14" targetFramework="net461" />
   <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net461" />
   <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
@@ -38,9 +40,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.1.0-beta4-10554" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.1.0-beta4-10554" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.1.0-beta4-11064" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11351" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Script" version="1.0.0-beta3-11375" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-beta3-10955" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11351" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Script.WebHost" version="1.0.0-beta3-11375" targetFramework="net461" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.1.0-beta4-11064" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
@@ -73,6 +75,7 @@
   <package id="NuGet.Frameworks" version="3.4.3" targetFramework="net461" />
   <package id="NuGet.LibraryModel" version="3.4.3" targetFramework="net461" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net461" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net461" />
   <package id="RestSharp" version="105.2.3" targetFramework="net461" />
   <package id="Sendgrid" version="8.0.5" targetFramework="net461" />
   <package id="SendGrid.CSharp.HTTP.Client" version="3.0.0" targetFramework="net461" />


### PR DESCRIPTION
Update to latest runtime version of WebJobs.Script which includes the proxy dlls for running locally