### PR TITLE
Mark experimental languages and templates in `func new` dialog

### DIFF
--- a/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
+++ b/src/Azure.Functions.Cli/Actions/LocalActions/CreateFunctionAction.cs
@@ -62,11 +62,11 @@ namespace Azure.Functions.Cli.Actions.LocalActions
             var templates = await _templatesManager.Templates;
 
             ColoredConsole.Write("Select a language: ");
-            var language = Language ?? ConsoleHelper.DisplaySelectionWizard(templates.Select(t => t.Metadata.Language).Distinct());
+            var language = UnformatLabel(Language ?? ConsoleHelper.DisplaySelectionWizard(templates.GroupBy(t => t.Metadata.Language).Select(g => FormatLabel(g.Key, g.All(t => t.Metadata.IsExperimental)))));
             ColoredConsole.WriteLine(TitleColor(language));
 
             ColoredConsole.Write("Select a template: ");
-            var name = TemplateName ?? ConsoleHelper.DisplaySelectionWizard(templates.Where(t => t.Metadata.Language.Equals(language, StringComparison.OrdinalIgnoreCase)).Select(t => t.Metadata.Name).Distinct());
+            var name = UnformatLabel(TemplateName ?? ConsoleHelper.DisplaySelectionWizard(templates.Where(t => t.Metadata.Language.Equals(language, StringComparison.OrdinalIgnoreCase)).Select(t => FormatLabel(t.Metadata.Name, t.Metadata.IsExperimental)).Distinct()));
             ColoredConsole.WriteLine(TitleColor(name));
 
             var template = templates.FirstOrDefault(t => t.Metadata.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && t.Metadata.Language.Equals(language, StringComparison.OrdinalIgnoreCase));
@@ -82,6 +82,9 @@ namespace Azure.Functions.Cli.Actions.LocalActions
                 functionName = string.IsNullOrEmpty(functionName) ? template.Metadata.DefaultFunctionName : functionName;
                 await _templatesManager.Deploy(functionName, template);
             }
+
+            string FormatLabel(string label, bool isExperimental) => label + (isExperimental ? " (Experimental)" : "");
+            string UnformatLabel(string label) => label.Replace(" (Experimental)", "");
         }
     }
 }

--- a/src/Azure.Functions.Cli/Common/Template.cs
+++ b/src/Azure.Functions.Cli/Common/Template.cs
@@ -34,7 +34,12 @@ namespace Azure.Functions.Cli.Common
         [JsonProperty("language")]
         public string Language { get; set; }
 
+        [JsonProperty("category")]
+        public IEnumerable<string> Category { get; set; }
+
         [JsonProperty("userPrompt")]
         public IEnumerable<string> UserPrompt { get; set; }
+
+        public bool IsExperimental => this.Category?.Any(c => c.Contains("experimental")) ?? false;
     }
 }


### PR DESCRIPTION
Implements #298
- Displays " (Experimental)" next to each template which is assigned to category experimental
- Displays " (Experimental)" next to each language for which all templates are experimental

The change is for 1.x branch, since 2.0 branches don't have experimental templates at all.

Note that PHP and TypeScript are not classified as experimental at the moment due to https://github.com/Azure/azure-webjobs-sdk-templates/issues/619. If/when that fix is merged, these languages will be shown as experimental with no further change required in CLI.