### PR TITLE
Added support for .net core debug in launch.json #361

### DIFF
--- a/src/Azure.Functions.Cli/Common/Constants.cs
+++ b/src/Azure.Functions.Cli/Common/Constants.cs
@@ -12,6 +12,7 @@ namespace Azure.Functions.Cli.Common
         public const string WebsiteHostname = "WEBSITE_HOSTNAME";
         public const int NodeDebugPort = 5858;
         public const int JavaDebugPort = 5005;
+        public const string DotNetClrProcessId = @"${command:pickProcess}";
 
         public static class Errors
         {

--- a/src/Azure.Functions.Cli/Helpers/DebuggerHelper.cs
+++ b/src/Azure.Functions.Cli/Helpers/DebuggerHelper.cs
@@ -50,6 +50,13 @@ namespace Azure.Functions.Cli.Helpers
                     Type = "java",
                     Request = "attach",
                     Port = Constants.JavaDebugPort
+                },
+                new VsCodeLaunchConfiguration
+                {
+                    Name = "Attach to Azure Functions (.NET)",
+                    Type = "coreclr",
+                    Request = "attach",
+                    ProcessId = Constants.DotNetClrProcessId
                 }
             }
         };
@@ -124,5 +131,8 @@ namespace Azure.Functions.Cli.Helpers
 
         [JsonProperty("port")]
         public int Port { get; set; }
+
+        [JsonProperty("processId")]
+        public string ProcessId { get; set; }
     }
 }


### PR DESCRIPTION
As per issue #361 I added support for debugging .NET Core Functions in the `launch.json` file for VS Code. This makes the experience a lot better and works out of the box! Only available against the v2 (core) branch as traditional v1 C# functions can't work or be debugged in VS code.